### PR TITLE
Fixes for GW150914 case

### DIFF
--- a/quickview.ipynb
+++ b/quickview.ipynb
@@ -65,7 +65,7 @@
     "url = urlformat.format(dataset, fortnight, filename)\n",
     "\n",
     "# -- Uncomment these 3 lines to run this notebook on GW150914 instead!\n",
-    "#t0 = 1126259462.39 # GW150914\n",
+    "#t0 = 1126259462.43 # GW150914\n",
     "#url = 'https://losc.ligo.org/s/events/GW150914/H-H1_LOSC_4_V1-1126259446-32.hdf5'\n",
     "#filename = url.split('/')[-1]"
    ]
@@ -196,7 +196,7 @@
    ],
    "source": [
     "#-- How much data to use for the ASD?\n",
-    "deltat = 16  # Number of seconds on each side of data\n",
+    "deltat = 8  # Number of seconds on each side of data\n",
     "N_samp = deltat*fs\n",
     "\n",
     "# -- Center the ASD segment on the requested time\n",


### PR DESCRIPTION
This fixes two issues when using the GW150914 example:

 * The end-time of GW150914 (in H1) is 1126259462.43 not 1126259462.39 (see for example discovery PRL)
 * Only 32s of data is read in for the GW150914 example. This is centred on 1126259462 so we cannot read 16s of data *after* GW150914 (there is only 15.57s available). This means that the event is then off-centre in the spectrograms. By reducing deltat to 8s the S6 example runs fine, and the GW150914 example is also centered.