### PR TITLE
Correct installation and import of packages

### DIFF
--- a/index.ipynb
+++ b/index.ipynb
@@ -62,33 +62,15 @@
    "cell_type": "code",
    "execution_count": 16,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<contextlib.ExitStack at 0x13b3bfe80>"
-      ]
-     },
-     "execution_count": 16,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "import requests, os\n",
-    "import matplotlib.pyplot as plt\n",
-    "%config InlineBackend.figure_format = 'retina'\n",
-    "\n",
     "try:\n",
     "    from gwpy.timeseries import TimeSeries\n",
     "except:\n",
-    "    ! pip install -q \"gwpy==3.0.9\"\n",
-    "    ! pip install -q \"matplotlib==3.7.3\"\n",
-    "    ! pip install -q \"astropy==6.1.4\"\n",
-    "    from gwpy.timeseries import TimeSeries  \n",
+    "    ! pip install -q \"gwpy==3.0.13\"\n",
+    "    from gwpy.timeseries import TimeSeries\n",
     "\n",
-    "# -- Turn on interactive plotting\n",
-    "plt.ion()"
+    "import matplotlib.pyplot as plt"
    ]
   },
   {

--- a/index.ipynb
+++ b/index.ipynb
@@ -59,6 +59,14 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Some packages may be missing on some platforms so we try to install them (you may see error messages when running on Google Colab but installation usually works).\n",
+    "If you experience problems, please [fill in an issue](https://github.com/gwosc-tutorial/quickview/issues)."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": 16,
    "metadata": {},

--- a/index.ipynb
+++ b/index.ipynb
@@ -63,7 +63,7 @@
    "metadata": {},
    "source": [
     "Some packages may be missing on some platforms so we try to install them (you may see error messages when running on Google Colab but installation usually works).\n",
-    "If you experience problems, please [fill in an issue](https://github.com/gwosc-tutorial/quickview/issues)."
+    "If you experience problems, please [report an issue](https://github.com/gwosc-tutorial/quickview/issues)."
    ]
   },
   {


### PR DESCRIPTION
This PR fixes #7 by changing the code to install packages.

The main idea is to install [gwpy 3.0.13](https://gitlab.com/gwpy/gwpy/-/releases/v3.0.13). This version is compatible with recent matlplotlib versions used on Colab. Tests show that it's not needed to explicitly install `matplotlib` and `astropy` (they are installed as pre-requisites of `gwpy`).

To smoothen usage inside and outside Colab:
- We import `matplotlib` after ensuring the presence of `gwpy`.
- We remove some matplotlib options that are no longer needed.

This works in a minimal virtual/conda env and on Colab.

Closes #7.